### PR TITLE
Allow user to supply own web3 instance. Make etherscan api key optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ const provider = "https://mainnet.infura.io/v3/<your_infura_api_key>";
 const etherscanApiKey = "<your_etherscan_api_key>"
 
 const options = {
-  provider,
+  provider, // Only required if not providing your own web3 instance
+  web3, // Only required if not providing your own provider
   etherscan: {
-    apiKey: etherscanApiKey,
+    apiKey: etherscanApiKey, // Only required if not providing abi in contract request configuration
     delayTime: 300, // delay time between etherscan ABI reqests. default is 300 ms
   },
 }

--- a/batchCall.js
+++ b/batchCall.js
@@ -6,18 +6,22 @@ const fetch = require("cross-fetch");
 
 class BatchCall {
   constructor(config) {
-    const { provider, etherscan } = config;
-    if (!provider) {
-      throw new Error("No provider set ser!");
+    const {web3, provider} = config;
+
+    if (typeof web3 === "undefined" && typeof provider === "undefined") {
+      throw new Error("You need to either provide a web3 instance or a provider string ser!");
     }
-    if (!etherscan) {
-      throw new Error("No etherscan config set ser!");
+
+    if (web3) {
+      this.web3 = web3;
     }
-    const { apiKey, delayTime = 300 } = etherscan;
-    if (!apiKey) {
-      throw new Error("No etherscan API key set ser!");
+    else {
+      this.web3 = new Web3(provider);
     }
-    this.web3 = new Web3(provider);
+
+    const { etherscan = {}} = config;
+    const { apiKey = null, delayTime = 300 } = etherscan;
+
     this.etherscanApiKey = apiKey;
     this.etherscanDelayTime = delayTime;
     this.abiHashByAddress = {};
@@ -235,6 +239,10 @@ class BatchCall {
 
   async fetchAbi(address) {
     const { etherscanApiKey } = this;
+    if (etherscanApiKey === null) {
+      throw new Error("No etherscan API key set ser! You either need to provide an etherscan API key, or provide your own ABI in your contract config.");
+    }
+
     let abi;
     let responseData;
     try {

--- a/batchCall.js
+++ b/batchCall.js
@@ -6,20 +6,21 @@ const fetch = require("cross-fetch");
 
 class BatchCall {
   constructor(config) {
-    const {web3, provider} = config;
+    const { web3, provider } = config;
 
     if (typeof web3 === "undefined" && typeof provider === "undefined") {
-      throw new Error("You need to either provide a web3 instance or a provider string ser!");
+      throw new Error(
+        "You need to either provide a web3 instance or a provider string ser!"
+      );
     }
 
     if (web3) {
       this.web3 = web3;
-    }
-    else {
+    } else {
       this.web3 = new Web3(provider);
     }
 
-    const { etherscan = {}} = config;
+    const { etherscan = {} } = config;
     const { apiKey = null, delayTime = 300 } = etherscan;
 
     this.etherscanApiKey = apiKey;
@@ -240,7 +241,9 @@ class BatchCall {
   async fetchAbi(address) {
     const { etherscanApiKey } = this;
     if (etherscanApiKey === null) {
-      throw new Error("No etherscan API key set ser! You either need to provide an etherscan API key, or provide your own ABI in your contract config.");
+      throw new Error(
+        "No etherscan API key set ser! You either need to provide an etherscan API key, or provide your own ABI in your contract config."
+      );
     }
 
     let abi;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-batch-call",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Constructor logic changed so have tested to ensure when.

- Passing neither web3 nor provider to constructor -> throw error
- Passing own web3 to constructor - works
- Passing provider string and no web3 instance to constructor - works
- Passing abi in contract config and no etherscan api key in contructor -> works 
- Passing no abi in contract config and no etherscan api key in constructor -> throws error
- Passing etherscan api key in constructor and no abi in contract config -> works
