### PR TITLE
Add flag to pull a block's meta data into the response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ https://batchcall.finance
     abi,                       // Specify an ABI to use for all addresses in this contract config. If no ABI is specified a unqiue ABI will be fetched and cached for every address. If contracts are supplied ABI is optional, but ABI is required regardless if the "allReadMethods" option is set
     store,                     // Specify a store to use for ABI caching. For front-end pass "localStorage." If no store is specified default to in-memory store
     groupByNamespace,          // Specify true/false (default is false). If true contracts will be groups hierarchicly by namespace
+    addBlockInfo,              // Specify true/false (default is false). If true every batch call will add the requested block's [meta data](https://web3js.readthedocs.io/en/v1.3.0/web3-eth.html#id59) to the response.
     logging,                   // Specify true/false (default is false). If true every batch call will print the number of methods invoked as well as total execution time
     simplifyResponse,          // Specify true/false (default is false). If true response args will only have one value instead of an array of values. For instance, "balanceOf: 3434452155", instead of "balanceOf: [{ value: 3434452155, input: 0x3464545, args: ['0x123...'] }]"
     allReadMethods,            // Specify true/flase (default is false). If true the contract ABI will be used to fetch state for all viewable methods with no inputs

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ https://batchcall.finance
     abi,                       // Specify an ABI to use for all addresses in this contract config. If no ABI is specified a unqiue ABI will be fetched and cached for every address. If contracts are supplied ABI is optional, but ABI is required regardless if the "allReadMethods" option is set
     store,                     // Specify a store to use for ABI caching. For front-end pass "localStorage." If no store is specified default to in-memory store
     groupByNamespace,          // Specify true/false (default is false). If true contracts will be groups hierarchicly by namespace
-    addBlockInfo,              // Specify true/false (default is false). If true every batch call will add the requested block's meta data to the response.
+    addBlockInfo,              // Specify true/false (default is false). If true every batch call will add the requested block's meta data to the response. Works only if groupByNamespace is set to true.
     logging,                   // Specify true/false (default is false). If true every batch call will print the number of methods invoked as well as total execution time
     simplifyResponse,          // Specify true/false (default is false). If true response args will only have one value instead of an array of values. For instance, "balanceOf: 3434452155", instead of "balanceOf: [{ value: 3434452155, input: 0x3464545, args: ['0x123...'] }]"
     allReadMethods,            // Specify true/flase (default is false). If true the contract ABI will be used to fetch state for all viewable methods with no inputs

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ https://batchcall.finance
     abi,                       // Specify an ABI to use for all addresses in this contract config. If no ABI is specified a unqiue ABI will be fetched and cached for every address. If contracts are supplied ABI is optional, but ABI is required regardless if the "allReadMethods" option is set
     store,                     // Specify a store to use for ABI caching. For front-end pass "localStorage." If no store is specified default to in-memory store
     groupByNamespace,          // Specify true/false (default is false). If true contracts will be groups hierarchicly by namespace
-    addBlockInfo,              // Specify true/false (default is false). If true every batch call will add the requested block's [meta data](https://web3js.readthedocs.io/en/v1.3.0/web3-eth.html#id59) to the response.
+    addBlockInfo,              // Specify true/false (default is false). If true every batch call will add the requested block's meta data to the response.
     logging,                   // Specify true/false (default is false). If true every batch call will print the number of methods invoked as well as total execution time
     simplifyResponse,          // Specify true/false (default is false). If true response args will only have one value instead of an array of values. For instance, "balanceOf: 3434452155", instead of "balanceOf: [{ value: 3434452155, input: 0x3464545, args: ['0x123...'] }]"
     allReadMethods,            // Specify true/flase (default is false). If true the contract ABI will be used to fetch state for all viewable methods with no inputs

--- a/batchCall.js
+++ b/batchCall.js
@@ -8,6 +8,7 @@ class BatchCall {
       web3,
       provider,
       groupByNamespace,
+      addBlockInfo,
       logging,
       simplifyResponse,
       store,
@@ -33,6 +34,7 @@ class BatchCall {
     this.abiHashByAddress = {};
     this.abiByHash = {};
     this.groupByNamespace = groupByNamespace;
+    this.addBlockInfo = addBlockInfo;
     this.logging = logging;
     this.simplifyResponse = simplifyResponse;
     this.readContracts = {};
@@ -272,6 +274,21 @@ class BatchCall {
       );
       contractsToReturn = contractsStateByNamespaceReduced;
     }
+
+    if (this.addBlockInfo) {
+      if (contractsToReturn && Object.keys(contractsToReturn).length > 0) {
+        if (!blockNumber) {
+          blockNumber = await web3.eth.getBlockNumber();
+        }
+        const blockInfo = await web3.eth.getBlock(blockNumber);
+        if (blockInfo) {
+          // see complete list here: https://web3js.readthedocs.io/en/v1.3.0/web3-eth.html#id59
+          const allowedFields = ['number', 'hash', 'gasLimit', 'gasUsed', 'timestamp'];
+          contractsToReturn['blockInfo'] = _.pick(blockInfo, allowedFields);
+        }
+      }
+    }
+
     if (this.logging) {
       const endTime = Date.now();
       const executionTime = endTime - startTime;

--- a/batchCall.js
+++ b/batchCall.js
@@ -273,18 +273,17 @@ class BatchCall {
         {}
       );
       contractsToReturn = contractsStateByNamespaceReduced;
-    }
-
-    if (this.addBlockInfo) {
-      if (contractsToReturn && Object.keys(contractsToReturn).length > 0) {
-        if (!blockNumber) {
-          blockNumber = await web3.eth.getBlockNumber();
-        }
-        const blockInfo = await web3.eth.getBlock(blockNumber);
-        if (blockInfo) {
-          // see complete list here: https://web3js.readthedocs.io/en/v1.3.0/web3-eth.html#id59
-          const allowedFields = ['number', 'hash', 'gasLimit', 'gasUsed', 'timestamp'];
-          contractsToReturn['blockInfo'] = _.pick(blockInfo, allowedFields);
+      if (this.addBlockInfo) {
+        if (contractsToReturn && Object.keys(contractsToReturn).length > 0) {
+          if (!blockNumber) {
+            blockNumber = await web3.eth.getBlockNumber();
+          }
+          const blockInfo = await web3.eth.getBlock(blockNumber);
+          if (blockInfo) {
+            // see complete list here: https://web3js.readthedocs.io/en/v1.3.0/web3-eth.html#id59
+            const allowedFields = ['number', 'hash', 'gasLimit', 'gasUsed', 'timestamp'];
+            contractsToReturn['blockInfo'] = _.pick(blockInfo, allowedFields);
+          }
         }
       }
     }


### PR DESCRIPTION
Hey,
I've added a little flag `addBlockInfo` which includes some block meta data into the response. It's not a big deal but it might be quite useful at the client side. The [`allowedFields` array](https://github.com/mosdefi/web3-batch-call/blob/master/batchCall.js#L286) is only there because the transactions for a given block might sometimes become quite big so I decided to do it the safe way first 😂 but could be also removed to export the entire block info.

what u think?